### PR TITLE
Aporte Reto-05

### DIFF
--- a/reto-05/lesclaz/app.py
+++ b/reto-05/lesclaz/app.py
@@ -11,22 +11,8 @@
 #  GNU General Public License for more details.
 #  #
 #  You should have received a copy of the GNU General Public License
-#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import os.path
-from pathlib import Path
-from xdg import xdg_config_home
-from utils import list_images
-from configurator import Configurator
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
-def main(app, config):
-    path = Path(xdg_config_home(), app)
-    configurator = Configurator(path, config)
-    data = configurator.read()
-    list_images(Path(data['directorio']))
-
-
-if __name__ == '__main__':
-    APP = "diogenes"
-    config = f"{APP}.conf"
-    main(APP, config)
+APP_NAME = "Diogenes"
+CONFIG_PATH = f"~/.config/{APP_NAME}"
+CONFIG_FILE = f"{APP_NAME}.conf"

--- a/reto-05/lesclaz/configurator.py
+++ b/reto-05/lesclaz/configurator.py
@@ -1,0 +1,82 @@
+#  Copyright (c) 2022. LESCLAZ.
+#  #
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  #
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  #
+#  You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+import toml
+
+from utils import get_downloads_dir
+
+
+class Configurator:
+
+    def __init__(self, path, config):
+        self.path = path
+        self.config_file = os.path.join(path, config)
+        self.directories = None
+        self.__verify_config_file()
+        self.__create_dirs()
+
+    def __create_dirs(self):
+        """
+        Crea los Directorios del archivo de configuracion que no esxixtan.
+        __ oculta la función impidiendo su acceso de forma sencilla.
+        """
+        if "Directorios" in self.read():
+            dirs = self.read()["Directorios"]
+            try:
+                for dir_ in dirs:
+                    os.makedirs(dirs[dir_]["in"], exist_ok=True)
+                    os.makedirs(dirs[dir_]["out"], exist_ok=True)
+            except KeyError:
+                raise Exception(
+                    "El archivo de configuracion esta mal escrito."
+                )
+
+    def __verify_config_file(self):
+        """
+        Verifica si existe el archivo pasado como parámetro al crear la
+        instancia de la clase, y de no ser así, lo crea.
+        __ oculta la función impidiendo su acceso de forma sencilla.
+
+        return:
+        """
+        os.makedirs(self.path, exist_ok=True)
+        if not os.path.exists(self.config_file):
+            with open(self.config_file, "w") as fp:
+                fp.write(toml.dumps({
+                    "Directorios": {
+                        "1": {
+                            "in": get_downloads_dir(),
+                            "out": get_downloads_dir()
+                        }
+                    }
+                }))
+
+    def read(self):
+        """
+        Lee el archivo de configuración y devuelve su contenido.
+
+        return:
+        """
+        with open(self.config_file) as f:
+            return toml.load(f)
+
+    def save(self, config: str or dict):
+        """
+        Guarda la configuracion en el archivo.
+        """
+        with open(self.config_file, "w") as file:
+            file.write(config if type(config) == str else toml.dumps(config))

--- a/reto-05/lesclaz/main.py
+++ b/reto-05/lesclaz/main.py
@@ -1,0 +1,76 @@
+#  Copyright (c) 2022. LESCLAZ.
+#  #
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  #
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  #
+#  You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import re
+import sys
+
+from app import CONFIG_PATH, CONFIG_FILE
+from configurator import Configurator
+from utils import list_images
+
+
+"""
+Lista todos los directorios "in" en el archivo de configuracion, de existir
+este, en caso contrario lo crea y le añade el directorio de descargas del
+usuario. Ademas si se ejecuta la app con el parametro -add añade el directorio
+al archivo de configuracion, ejemplo: python3 main.py -add {nombre del la
+seccion} {ruta directorio in} {ruta directorio out}. no se usan las llaves.
+"""
+
+
+def listar(dir_to_list):
+    print(f"Directorio: {dir_to_list}")
+    for i, file in enumerate(list_images(dir_to_list)):
+        file = file.lower() if re.findall('[0-9]+', file) else file.upper()
+        print(f'{i} => {file}' if i % 2 == 0 else f'{i} {file}')
+    print("\n")
+
+
+def add_dir_conf(dir_conf: dict):
+    config = Configurator(CONFIG_PATH, CONFIG_FILE)
+    conf = config.read()
+    conf['Directorios'] = {
+        **conf['Directorios'],
+        **dir_conf['Directorios']
+    }
+    config.save(conf)
+
+
+def main():
+    config = Configurator(CONFIG_PATH, CONFIG_FILE)
+    dirs_conf = config.read()["Directorios"]
+    for dir_ in dirs_conf:
+        listar(dirs_conf[dir_]["in"])
+
+
+if __name__ == '__main__':
+    if len(sys.argv) == 1:
+        main()
+    elif sys.argv[1] == "-add":
+        add_dir_conf(
+            {
+                "Directorios": {
+                    sys.argv[2]: {
+                        "in": sys.argv[3],
+                        "out": sys.argv[4]
+                    }
+                }
+            }
+        )
+    elif sys.argv[1] == "-h":
+        print("""
+        Uso: python3 main.py -add {name config dir} {dir "in"} {dir "out"}
+        """)
+    else:
+        print("Mala ejecucion")

--- a/reto-05/lesclaz/utils.py
+++ b/reto-05/lesclaz/utils.py
@@ -1,0 +1,49 @@
+#  Copyright (c) 2022. LESCLAZ.
+#  #
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  #
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  #
+#  You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import mimetypes
+import os
+from pathlib import Path
+
+import toml
+from xdg import xdg_config_home
+
+
+def get_downloads_dir():
+    """
+    Localiza y devuelve la ruta hacia la carpeta de descargas del usuario
+    que ejecuta la app.
+    """
+    path_to_user_dirs = Path(xdg_config_home() / "user-dirs.dirs")
+    if os.path.exists(path_to_user_dirs):
+        with open(path_to_user_dirs) as conf_dirs:
+            user_dirs = toml.load(conf_dirs)
+            return os.path.join(os.path.expanduser("~"),
+                                user_dirs["XDG_DOWNLOAD_DIR"]
+                                .replace("$HOME/", ""))
+
+
+def list_images(dir_to_list):
+    """
+    Lista los archivos de imagen JPEG dentro del directorio pasado como
+    parámetro.
+
+    return:
+    """
+    return [file for file in os.listdir(dir_to_list)
+            if os.path.isfile(
+            os.path.join(dir_to_list, file)) and
+            mimetypes.guess_type(os.path.join(
+                dir_to_list, file))[0] == 'image/jpeg']


### PR DESCRIPTION
Lista todos los directorios "in" en el archivo de configuración, de existir
este, en caso contrario lo crea y le añade el directorio de descargas del
usuario. Ademas si se ejecuta la app con el parámetro -add añade el directorio
al archivo de configuración, ejemplo: `python3 main.py -add pepito /home/user/pepito/in /home/user/pepito/out`.


PD: Lo hice un poco a mi manera ya que este reto no proporciono README.md